### PR TITLE
Improvements for content embedded in NavigationView

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ struct ContentView: View {
 
 Check out [documentation comments](Sources/SwiftUITabsView/TabsView.swift) and the included [example app](Example/ExampleApp/Example.swift).
 
+If your tab's content view is embedded in `NavigationView`, use [tabsBarSafeAreaInset](Sources/SwiftUITabsView/TabsBarSafeAreaInsetViewModifier.swift) modifier to apply safe area insets that matches the tabs bar:
+
+```swift
+TabsView(
+  /* ... */
+  content: { tab in 
+    NavigationView {
+      ContentView(for: tab)
+        .tabsBarSafeAreaInset()
+    }
+  }
+)
+```
+
 ## 🛠 Development
 
 Open `SwiftUITabsView.xcworkspace` in Xcode (≥13.1) for development.

--- a/Sources/SwiftUITabsView/TabsBarSafeAreaInsetViewModifier.swift
+++ b/Sources/SwiftUITabsView/TabsBarSafeAreaInsetViewModifier.swift
@@ -12,7 +12,7 @@ extension EnvironmentValues {
 }
 
 struct TabsBarSafeAreaInsetViewModifier: ViewModifier {
-  var position: ToolbarPosition
+  @Environment(\.toolbarPosition) var position
   @Environment(\.tabsBarSafeAreaInset) var tabsBarSafeAreaInset
 
   func body(content: Content) -> some View {
@@ -44,11 +44,8 @@ extension View {
   /// )
   /// ```
   ///
-  /// - Parameter position: Toolbar position (default is `.bottom`).
   /// - Returns: View with additional safe area insets matching the tabs bar.
-  public func tabsBarSafeAreaInset(
-    position: ToolbarPosition = .bottom
-  ) -> some View {
-    modifier(TabsBarSafeAreaInsetViewModifier(position: position))
+  public func tabsBarSafeAreaInset() -> some View {
+    modifier(TabsBarSafeAreaInsetViewModifier())
   }
 }

--- a/Sources/SwiftUITabsView/TabsBarSafeAreaInsetViewModifier.swift
+++ b/Sources/SwiftUITabsView/TabsBarSafeAreaInsetViewModifier.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct TabsBarSafeAreaInsetKey: EnvironmentKey {
+  static var defaultValue: CGSize = .zero
+}
+
+extension EnvironmentValues {
+  var tabsBarSafeAreaInset: CGSize {
+    get { self[TabsBarSafeAreaInsetKey.self] }
+    set { self[TabsBarSafeAreaInsetKey.self] = newValue }
+  }
+}
+
+struct TabsBarSafeAreaInsetViewModifier: ViewModifier {
+  var position: ToolbarPosition
+  @Environment(\.tabsBarSafeAreaInset) var tabsBarSafeAreaInset
+
+  func body(content: Content) -> some View {
+    content
+      .safeAreaInset(edge: position.verticalEdge) {
+        Color.clear.frame(
+          width: tabsBarSafeAreaInset.width,
+          height: tabsBarSafeAreaInset.height
+        )
+      }
+  }
+}
+
+extension View {
+  /// Add safe area inset for tabs bar.
+  ///
+  /// Use this modifier if your tab's content is embedded in `NavigationView`.
+  /// Apply it on the content inside the `NavigationView`.
+  ///
+  /// ```swift
+  /// TabsView(
+  ///   /* ... */
+  ///   content: { tab in
+  ///     NavigationView {
+  ///       ContentView(for: tab)
+  ///         .tabsBarSafeAreaInset()
+  ///     }
+  ///   }
+  /// )
+  /// ```
+  ///
+  /// - Parameter position: Toolbar position (default is `.bottom`).
+  /// - Returns: View with additional safe area insets matching the tabs bar.
+  public func tabsBarSafeAreaInset(
+    position: ToolbarPosition = .bottom
+  ) -> some View {
+    modifier(TabsBarSafeAreaInsetViewModifier(position: position))
+  }
+}

--- a/Sources/SwiftUITabsView/ToolbarViewModifier.swift
+++ b/Sources/SwiftUITabsView/ToolbarViewModifier.swift
@@ -60,18 +60,6 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
   @State var contentFrame: CGRect?
   @State var tabsBarFrame: CGRect?
 
-  var barSafeArea: CGSize {
-    guard let contentFrame = contentFrame,
-          let tabsBarFrame = tabsBarFrame
-    else { return .zero }
-
-    var size = contentFrame.intersection(tabsBarFrame).size
-    size.width = max(0, size.width)
-    size.height = max(0, size.height)
-
-    return size
-  }
-
   var keyboardSafeAreaEdges: Edge.Set {
     guard ignoresKeyboard else { return [] }
     switch position {
@@ -84,12 +72,7 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
     ZStack {
       content
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .safeAreaInset(edge: position.verticalEdge) {
-          Color.clear.frame(
-            width: barSafeArea.width,
-            height: barSafeArea.height
-          )
-        }
+        .tabsBarSafeAreaInset(position: position)
         .geometryReader(
           geometry: { $0.frame(in: .global) },
           onChange: { frame in
@@ -111,6 +94,17 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: position.frameAlignment)
         .ignoresSafeArea(.keyboard, edges: keyboardSafeAreaEdges)
     }
+    .environment(\.tabsBarSafeAreaInset, {
+      guard let contentFrame = contentFrame,
+            let tabsBarFrame = tabsBarFrame
+      else { return .zero }
+
+      var size = contentFrame.intersection(tabsBarFrame).size
+      size.width = max(0, size.width)
+      size.height = max(0, size.height)
+
+      return size
+    }())
   }
 }
 

--- a/Sources/SwiftUITabsView/ToolbarViewModifier.swift
+++ b/Sources/SwiftUITabsView/ToolbarViewModifier.swift
@@ -23,6 +23,17 @@ public enum ToolbarPosition: Equatable {
   }
 }
 
+struct ToolbarPositionKey: EnvironmentKey {
+  static var defaultValue: ToolbarPosition = .bottom
+}
+
+extension EnvironmentValues {
+  var toolbarPosition: ToolbarPosition {
+    get { self[ToolbarPositionKey.self] }
+    set { self[ToolbarPositionKey.self] = newValue }
+  }
+}
+
 extension View {
   func toolbar<Bar: View>(
     position: ToolbarPosition = .bottom,
@@ -31,32 +42,30 @@ extension View {
     @ViewBuilder bar: @escaping () -> Bar
   ) -> some View {
     modifier(ToolbarViewModifier(
-      position: position,
       ignoresKeyboard: ignoresKeyboard,
       frameChangeAnimation: frameChangeAnimation,
       bar: bar
     ))
+      .environment(\.toolbarPosition, position)
   }
 }
 
 struct ToolbarViewModifier<Bar: View>: ViewModifier {
   init(
-    position: ToolbarPosition = .bottom,
     ignoresKeyboard: Bool = true,
     frameChangeAnimation: Animation? = .default,
     @ViewBuilder bar: @escaping () -> Bar
   ) {
-    self.position = position
     self.ignoresKeyboard = ignoresKeyboard
     self.frameChangeAnimation = frameChangeAnimation
     self.bar = bar
   }
 
-  var position: ToolbarPosition
   var ignoresKeyboard: Bool
   var frameChangeAnimation: Animation?
   var bar: () -> Bar
 
+  @Environment(\.toolbarPosition) var position
   @State var contentFrame: CGRect?
   @State var tabsBarFrame: CGRect?
 

--- a/Sources/SwiftUITabsView/ToolbarViewModifier.swift
+++ b/Sources/SwiftUITabsView/ToolbarViewModifier.swift
@@ -81,7 +81,7 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
     ZStack {
       content
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .tabsBarSafeAreaInset(position: position)
+        .tabsBarSafeAreaInset()
         .geometryReader(
           geometry: { $0.frame(in: .global) },
           onChange: { frame in

--- a/Sources/SwiftUITabsView/ToolbarViewModifier.swift
+++ b/Sources/SwiftUITabsView/ToolbarViewModifier.swift
@@ -68,6 +68,7 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
   @Environment(\.toolbarPosition) var position
   @State var contentFrame: CGRect?
   @State var tabsBarFrame: CGRect?
+  @State var tabsBarSafeAreaInset: CGSize = .zero
 
   var keyboardSafeAreaEdges: Edge.Set {
     guard ignoresKeyboard else { return [] }
@@ -87,6 +88,7 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
           onChange: { frame in
             withAnimation(contentFrame == nil ? .none : frameChangeAnimation) {
               contentFrame = frame
+              tabsBarSafeAreaInset = makeTabsBarSafeAreaInset()
             }
           }
         )
@@ -97,23 +99,26 @@ struct ToolbarViewModifier<Bar: View>: ViewModifier {
           onChange: { frame in
             withAnimation(tabsBarFrame == nil ? .none : frameChangeAnimation) {
               tabsBarFrame = frame
+              tabsBarSafeAreaInset = makeTabsBarSafeAreaInset()
             }
           }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: position.frameAlignment)
         .ignoresSafeArea(.keyboard, edges: keyboardSafeAreaEdges)
     }
-    .environment(\.tabsBarSafeAreaInset, {
-      guard let contentFrame = contentFrame,
-            let tabsBarFrame = tabsBarFrame
-      else { return .zero }
+    .environment(\.tabsBarSafeAreaInset, tabsBarSafeAreaInset)
+  }
 
-      var size = contentFrame.intersection(tabsBarFrame).size
-      size.width = max(0, size.width)
-      size.height = max(0, size.height)
+  func makeTabsBarSafeAreaInset() -> CGSize {
+    guard let contentFrame = contentFrame,
+          let tabsBarFrame = tabsBarFrame
+    else { return .zero }
 
-      return size
-    }())
+    var size = contentFrame.intersection(tabsBarFrame).size
+    size.width = max(0, size.width)
+    size.height = max(0, size.height)
+
+    return size
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue when the tab's content embedded in `NavigationView` is covered by the tabs bar.

## What was done

- [x] Add `.tabsBarSafeAreaInset` view modifier.
- [x] Update how safe area inset for the tabs bar is applied on the content.
- [x] Improve performance by computing safe area inset only when needed.
